### PR TITLE
Compare sizes only for existing files

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,10 @@ function getPath(opts) {
 		}
 	}
 
-	return Array.from(paths).map(fp => {
-		try {
-			return {fp, size: fs.statSync(fp).size};
-		} catch (err) {
-			return {};
-		}
-	}).reduce((a, b) => a.size > b.size ? a : b).fp;
+	return Array.from(paths)
+		.filter(fs.existsSync)
+		.map(fp => ({fp, size: fs.statSync(fp).size}))
+		.reduce((a, b) => a.size > b.size ? a : b).fp;
 }
 
 module.exports = opts => {


### PR DESCRIPTION
I don't have ~/.history on my machine and it leads to wrong result: 

<img width="1392" alt="screen shot 2017-02-10 at 15 20 02" src="https://cloud.githubusercontent.com/assets/594298/22829803/8fe26dbc-efa4-11e6-8b21-affb7e48f582.png">

Since `594621 > {}.size` is `false`, using this package fails with error:

```
TypeError: path must be a string or Buffer
    at TypeError (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.fs.readFileSync (fs.js:508:33)
    at module.exports.opts (/Users/KELiON/projects/cerebro-shell/node_modules/shell-history/index.js:60:18)
    at repl:1:25
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
```

In this PR I've added filtering for only existing history files 